### PR TITLE
Allow arrays for channels to multi-set

### DIFF
--- a/leddriver.js
+++ b/leddriver.js
@@ -109,14 +109,28 @@ exports = module.exports = function(channelcount, bitperchannel, spidevice) {
               rgb.b = 1 - rgb.b;
             }
             
-            this.pset(redchannel, rgb.r);
-            this.pset(greenchannel, rgb.g);
-            this.pset(bluechannel, rgb.b);
-
-            if( typeof(bluechannel2) != "undefined" ) {
-
-                this.pset(bluechannel2, rgb.b);
-
+            if(Array.isArray(redchannel)) {
+              redchannel.forEach(function(chan) {
+                this.pset(chan, rgb.r);
+              });
+            } else {
+              this.pset(redchannel, rgb.r);
+            }
+            
+            if(Array.isArray(greenchannel)) {
+              greenchannel.forEach(function(chan) {
+                this.pset(chan, rgb.g);
+              });
+            } else {
+              this.pset(greenchannel, rgb.g);
+            }
+            
+            if(Array.isArray(bluechannel)) {
+              bluechannel.forEach(function(chan) {
+                this.pset(chan, rgb.b);
+              });
+            } else {
+              this.pset(bluechannel, rgb.b);
             }
 
         },

--- a/leddriver.js
+++ b/leddriver.js
@@ -99,7 +99,7 @@ exports = module.exports = function(channelcount, bitperchannel, spidevice) {
             return true;
         },
 
-        setRGB: function(hexcolor, redchannel, greenchannel, bluechannel, bluechannel2) {
+        setRGB: function(hexcolor, redchannel, greenchannel, bluechannel) {
 
             var rgb = this._getRGBfromHex(hexcolor);
 


### PR DESCRIPTION
`setRGB('#ffffff', 0, 1, [2, 3])`

This is to generalize your requirement for "two blue leds" while allowing setting of multiple channels at the same time.  This way, you can set multiple strands the same color, at the same time, with one sexy call.

`setRGB('#ffffff', [0, 3, 6, 9], [1, 4, 7, 10], [2, 5, 8, 11])` will set four strands of RGB LEDs fully on (white) at the same time.
